### PR TITLE
Hexo 7.0 脚本兼容 & 细节修改

### DIFF
--- a/includes/tasks/welcome.js
+++ b/includes/tasks/welcome.js
@@ -1,6 +1,6 @@
-const logger = require('hexo-log')();
-
-logger.info(`
+module.exports = (hexo) => {
+    hexo.log.info(`
 =============================================
 Welcome from Anatolo!
 =============================================`);
+}

--- a/layout/index.pug
+++ b/layout/index.pug
@@ -5,5 +5,6 @@ block content
             include mixins
             +make_post(item, false)
         - })
-        include mixins
-        +make_pager(__('prev'), __('next'))
+        if site.posts.length>config.index_generator.per_page
+            include mixins
+            +make_pager(__('prev'), __('next'))

--- a/layout/index.pug
+++ b/layout/index.pug
@@ -5,6 +5,6 @@ block content
             include mixins
             +make_post(item, false)
         - })
-        if site.posts.length>config.index_generator.per_page
+        if site.posts.length>config.index_generator.per_page && ( config.per_page != 0 || config.index_generator.per_page != 0 )
             include mixins
             +make_pager(__('prev'), __('next'))

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,4 +1,4 @@
-require('../includes/tasks/welcome');
+require('../includes/tasks/welcome')(hexo);
 require('../includes/generators/insight')(hexo);
 require('../includes/generators/site_json')(hexo);
 require('../includes/generators/tags')(hexo);


### PR DESCRIPTION
- 修复了 Hexo 7.0 时 welcome.js 输出问候出错的问题
- 当总文章数小于站点配置中主页每页文章数 或 per_page 为 0 时将不再渲染空的切换div