### PR TITLE
Revert "修复子路径下RSS地址错误"

### DIFF
--- a/layout/partial/social_links.pug
+++ b/layout/partial/social_links.pug
@@ -8,7 +8,7 @@ ul.social-links
             i.fa.fa-envelope
       when "rss"
         li
-          a(url_for(link))
+          a(href=link)
             i.fa.fa-rss
       default
         li


### PR DESCRIPTION
Reverts Lhcfl/hexo-theme-anatolo#30

考虑到该 URL 可能可以填写非本站的href，Revert这个PR。