### PR TITLE
更新 friend-link.tsx 中对友链和图片链接的处理逻辑

### DIFF
--- a/src/utils/friend-link.tsx
+++ b/src/utils/friend-link.tsx
@@ -7,11 +7,11 @@ export function make_friends_list() {
       <div class="friend-link-container">
         <div class="friend-link-box">
           <aside class="friend-link-avatar">
-            <img src={escapeHTML(avatar)} href={escapeHTML(href)} />
+            <img src={avatar} href={href} />
           </aside>
           <div class="friend-link-meta">
             <div class="friend-link-title">
-              <a href={escapeHTML(href)}>{escapeHTML(title)}</a>
+              <a href={href}>{escapeHTML(title)}</a>
             </div>
             <div class="friend-link-description">{escapeHTML(description)}</div>
           </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f734662f-8dbd-4578-872f-a60343b6e028)
现有代码 [/src/utils/friend-link.tsx](https://github.com/Lhcfl/hexo-theme-anatolo/blob/master/src/utils/friend-link.tsx) 中 L10, 14 对链接的处理有误：其将源 markdown 文件中提供的链接进行转义，致使请求出错。
链接应当按原样提供，不应被转义。
commit 后经本地测试，该问题消失。